### PR TITLE
feature: simplify gitlab module

### DIFF
--- a/modules/github/README.md
+++ b/modules/github/README.md
@@ -1,0 +1,38 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_default"></a> [default](#module\_default) | ../../ | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_create_oidc_provider"></a> [create\_oidc\_provider](#input\_create\_oidc\_provider) | Toggle to whether or not create the oidc provider. Put to false to not create the oidc provider but instead data source it and create roles only. | `bool` | `true` | no |
+| <a name="input_iam_roles"></a> [iam\_roles](#input\_iam\_roles) | Configuration for IAM roles, the key of the map is used as the IAM role name. Unless overwritten by setting the name field. | <pre>map(object({<br/>    description              = optional(string, "Role assumed by the GitHub IAM OIDC provider")<br/>    name                     = optional(string, null)<br/>    path                     = optional(string, "/")<br/>    permissions_boundary_arn = optional(string, "")<br/>    policy                   = optional(string, null)<br/>    policy_arns              = optional(set(string), [])<br/><br/>    subject_filter = object({<br/>      repository  = string<br/>      branch      = optional(string)<br/>      environment = optional(string)<br/>      tag         = optional(string)<br/>    })<br/>  }))</pre> | `{}` | no |
+| <a name="input_oidc_provider"></a> [oidc\_provider](#input\_oidc\_provider) | Configuration of the OIDC provider. | <pre>object({<br/>    client_ids     = optional(list(string), ["sts.amazonaws.com"])<br/>    name           = optional(string, "GitHub")<br/>    thumbprint_url = optional(string, "https://token.actions.githubusercontent.com/.well-known/openid-configuration")<br/>    url            = optional(string, "https://token.actions.githubusercontent.com")<br/>  })</pre> | `{}` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources. | `map(string)` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_iam_roles"></a> [iam\_roles](#output\_iam\_roles) | Map GitHub OIDC IAM roles name and ARN |
+<!-- END_TF_DOCS -->

--- a/modules/gitlab/README.md
+++ b/modules/gitlab/README.md
@@ -1,0 +1,38 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_default"></a> [default](#module\_default) | ../../ | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_create_oidc_provider"></a> [create\_oidc\_provider](#input\_create\_oidc\_provider) | Toggle to whether or not create the oidc provider. Put to false to not create the oidc provider but instead data source it and create roles only. | `bool` | `true` | no |
+| <a name="input_iam_roles"></a> [iam\_roles](#input\_iam\_roles) | Configuration for IAM roles, the key of the map is used as the IAM role name. Unless overwritten by setting the name field. | <pre>map(object({<br/>    description              = optional(string, "Role assumed by the GitLab IAM OIDC provider")<br/>    name                     = optional(string, null)<br/>    path                     = optional(string, "/")<br/>    permissions_boundary_arn = optional(string, "")<br/>    policy                   = optional(string, null)<br/>    policy_arns              = optional(set(string), [])<br/><br/>    subject_filter = object({<br/>      project_path = string<br/>      ref_type     = string<br/>      ref          = string<br/>    })<br/>  }))</pre> | `{}` | no |
+| <a name="input_oidc_provider"></a> [oidc\_provider](#input\_oidc\_provider) | Configuration of the OIDC provider. | <pre>object({<br/>    name = optional(string, "GitLab")<br/>    url  = optional(string, "https://gitlab.com")<br/>  })</pre> | `{}` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources. | `map(string)` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_iam_roles"></a> [iam\_roles](#output\_iam\_roles) | Map GitHub OIDC IAM roles name and ARN |
+<!-- END_TF_DOCS -->

--- a/modules/gitlab/main.tf
+++ b/modules/gitlab/main.tf
@@ -2,8 +2,16 @@ module "default" {
   source = "../../"
 
   create_oidc_provider = var.create_oidc_provider
-  oidc_provider        = var.oidc_provider
   tags                 = var.tags
+
+  # https://docs.gitlab.com/ci/cloud_services/aws/
+  # The GitLab URL is used as the unique identifier (client_id) for the OIDC provider.
+  # This ensures that the IAM role trust relationship in AWS correctly identifies GitLab as the issuer.
+  # We default both client_ids and thumbprint_url to the GitLab URL to ensure a consistent and secure integration.
+  oidc_provider = merge(var.oidc_provider, {
+    client_ids     = [var.oidc_provider.url],
+    thumbprint_url = var.oidc_provider.url
+  })
 
   # A concatenation of metadata describing the GitLab CI/CD workflow including the group, project, branch, and tag. The sub field is in the following format:
   # project_path:{group}/{project}:ref_type:{type}:ref:{branch_name}

--- a/modules/gitlab/variables.tf
+++ b/modules/gitlab/variables.tf
@@ -6,10 +6,8 @@ variable "create_oidc_provider" {
 
 variable "oidc_provider" {
   type = object({
-    client_ids     = optional(list(string), ["https://gitlab.com"])
-    name           = optional(string, "GitLab")
-    thumbprint_url = optional(string, "https://gitlab.com")
-    url            = optional(string, "https://gitlab.com")
+    name = optional(string, "GitLab")
+    url  = optional(string, "https://gitlab.com")
   })
   default     = {}
   description = "Configuration of the OIDC provider."

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,11 @@ variable "oidc_provider" {
     url            = string
   })
   description = "Configuration of the OIDC provider."
+
+  validation {
+    condition     = can(regex("^https", var.oidc_provider.url))
+    error_message = "URL should start with 'https'."
+  }
 }
 
 variable "iam_roles" {


### PR DESCRIPTION
Make the input more similar to the "old" module: https://github.com/schubergphilis/terraform-aws-mcaf-gitlab-oidc/blob/main/main.tf

Simplify the input as only the url is needed. 

Moreover, added back the URL validation as that was also in the "old" module. 