### PR TITLE
fix: solve isse with github url malformed during certificat retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ IMPORTANT: We do not pin modules to versions in our examples. We highly recommen
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
+| <a name="requirement_corefunc"></a> [corefunc](#requirement\_corefunc) | ~> 1.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0.0 |
 
 ## Providers

--- a/examples/custom/main.tf
+++ b/examples/custom/main.tf
@@ -2,6 +2,8 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+provider "corefunc" {}
+
 module "custom_oidc" {
   source = "../.."
 

--- a/examples/custom/terraform.tf
+++ b/examples/custom/terraform.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.0.0"
     }
+    corefunc = {
+      source  = "northwood-labs/corefunc"
+      version = "~> 1.0"
+    }
     tls = {
       source  = "hashicorp/tls"
       version = ">= 4.0.0"

--- a/examples/github/main.tf
+++ b/examples/github/main.tf
@@ -2,6 +2,8 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+provider "corefunc" {}
+
 module "github_oidc" {
   source = "../..//modules/github"
 

--- a/examples/github/terraform.tf
+++ b/examples/github/terraform.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.0.0"
     }
+    corefunc = {
+      source  = "northwood-labs/corefunc"
+      version = "~> 1.0"
+    }
     tls = {
       source  = "hashicorp/tls"
       version = ">= 4.0.0"

--- a/examples/gitlab/main.tf
+++ b/examples/gitlab/main.tf
@@ -2,6 +2,8 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+provider "corefunc" {}
+
 module "gitlab_oidc" {
   source = "../..//modules/gitlab"
 

--- a/examples/gitlab/terraform.tf
+++ b/examples/gitlab/terraform.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.0.0"
     }
+    corefunc = {
+      source  = "northwood-labs/corefunc"
+      version = "~> 1.0"
+    }
     tls = {
       source  = "hashicorp/tls"
       version = ">= 4.0.0"

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.0.0"
     }
+    corefunc = {
+      source  = "northwood-labs/corefunc"
+      version = "~> 1.0"
+    }
     tls = {
       source  = "hashicorp/tls"
       version = ">= 4.0.0"

--- a/variables.tf
+++ b/variables.tf
@@ -14,8 +14,8 @@ variable "oidc_provider" {
   description = "Configuration of the OIDC provider."
 
   validation {
-    condition     = can(regex("^https", var.oidc_provider.url))
-    error_message = "URL should start with 'https'."
+    condition     = can(regex("^https", var.oidc_provider.url)) && !endswith(var.oidc_provider.url, "/")
+    error_message = "URL should start with 'https' and not end with a '/'."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -14,8 +14,8 @@ variable "oidc_provider" {
   description = "Configuration of the OIDC provider."
 
   validation {
-    condition     = can(regex("^https", var.oidc_provider.url)) && !endswith(var.oidc_provider.url, "/")
-    error_message = "URL should start with 'https' and not end with a '/'."
+    condition     = can(regex("^https", var.oidc_provider.url))
+    error_message = "URL should start with 'https'."
   }
 }
 


### PR DESCRIPTION
Need to properly transform url's to work with tls:

- `https://gitlab.com` -> `tls://gitlab.com:443`
- `https://token.actions.githubusercontent.com/.well-known/openid-configuration` -> `tls://token.actions.githubusercontent.com:443/.well-known/openid-configuration`

Solves issue: 
│ Port missing from URL:
│ tls://token.actions.githubusercontent.com/.well-known/openid-configuration:443

