### PR TITLE
fix: client_ids and thumbprint_url are only needed when the oidc provider is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ IMPORTANT: We do not pin modules to versions in our examples. We highly recommen
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
 | <a name="requirement_corefunc"></a> [corefunc](#requirement\_corefunc) | ~> 1.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0.0 |
@@ -42,7 +42,7 @@ IMPORTANT: We do not pin modules to versions in our examples. We highly recommen
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_oidc_provider"></a> [oidc\_provider](#input\_oidc\_provider) | Configuration of the OIDC provider. | <pre>object({<br/>    client_ids     = list(string)<br/>    thumbprint_url = string<br/>    url            = string<br/>  })</pre> | n/a | yes |
+| <a name="input_oidc_provider"></a> [oidc\_provider](#input\_oidc\_provider) | Configuration of the OIDC provider. | <pre>object({<br/>    client_ids     = optional(list(string))<br/>    thumbprint_url = optional(string)<br/>    url            = string<br/>  })</pre> | n/a | yes |
 | <a name="input_create_oidc_provider"></a> [create\_oidc\_provider](#input\_create\_oidc\_provider) | Toggle to whether or not create the oidc provider. Put to false to not create the oidc provider but instead data source it and create roles only. | `bool` | `true` | no |
 | <a name="input_iam_roles"></a> [iam\_roles](#input\_iam\_roles) | Configuration of the IAM roles, the key of the map is used as the IAM role name. Unless overwritten by setting the name field. | <pre>map(object({<br/>    audience_filters         = optional(list(string), [])<br/>    description              = optional(string, "Role assumed by the IAM OIDC provider")<br/>    name                     = optional(string, null)<br/>    path                     = optional(string, "/")<br/>    permissions_boundary_arn = optional(string, "")<br/>    policy                   = optional(string, null)<br/>    policy_arns              = optional(set(string), [])<br/>    subject_filters          = list(string)<br/>  }))</pre> | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources. | `map(string)` | `null` | no |

--- a/examples/custom/terraform.tf
+++ b/examples/custom/terraform.tf
@@ -14,5 +14,5 @@ terraform {
     }
   }
 
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
 }

--- a/examples/github/terraform.tf
+++ b/examples/github/terraform.tf
@@ -14,5 +14,5 @@ terraform {
     }
   }
 
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
 }

--- a/examples/gitlab/terraform.tf
+++ b/examples/gitlab/terraform.tf
@@ -14,5 +14,5 @@ terraform {
     }
   }
 
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
 }

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,8 @@ locals {
 # We avoid using https scheme because the Hashicorp TLS provider has started following redirects starting v4.
 # See https://github.com/hashicorp/terraform-provider-tls/issues/249
 data "tls_certificate" "default" {
+  for_each = var.create_oidc_provider ? { create = true } : {}
+
   url = "tls://${local.thumbprint_url_parse.host}:443${local.thumbprint_url_parse.path}"
 }
 
@@ -24,7 +26,7 @@ resource "aws_iam_openid_connect_provider" "default" {
 
   url             = var.oidc_provider.url
   client_id_list  = var.oidc_provider.client_ids
-  thumbprint_list = [data.tls_certificate.default.certificates[0].sha1_fingerprint]
+  thumbprint_list = [data.tls_certificate.default["create"].certificates[0].sha1_fingerprint]
   tags            = var.tags
 }
 

--- a/modules/github/README.md
+++ b/modules/github/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0.0 |
 

--- a/modules/github/terraform.tf
+++ b/modules/github/terraform.tf
@@ -10,5 +10,5 @@ terraform {
     }
   }
 
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
 }

--- a/modules/gitlab/README.md
+++ b/modules/gitlab/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0.0 |
 

--- a/modules/gitlab/terraform.tf
+++ b/modules/gitlab/terraform.tf
@@ -10,5 +10,5 @@ terraform {
     }
   }
 
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
 }

--- a/moved.tf
+++ b/moved.tf
@@ -2,3 +2,8 @@ moved {
   from = aws_iam_openid_connect_provider.default["instance"]
   to   = aws_iam_openid_connect_provider.default["create"]
 }
+
+moved {
+  from = data.tls_certificate.default
+  to   = data.tls_certificate.default["create"]
+}

--- a/terraform.tf
+++ b/terraform.tf
@@ -14,5 +14,5 @@ terraform {
     }
   }
 
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,15 +6,26 @@ variable "create_oidc_provider" {
 
 variable "oidc_provider" {
   type = object({
-    client_ids     = list(string)
-    thumbprint_url = string
+    client_ids     = optional(list(string))
+    thumbprint_url = optional(string)
     url            = string
   })
   description = "Configuration of the OIDC provider."
 
   validation {
     condition     = can(regex("^https", var.oidc_provider.url))
-    error_message = "URL should start with 'https'."
+    error_message = "`url` should start with 'https'."
+  }
+
+  validation {
+    condition = (
+      !var.create_oidc_provider ||
+      (
+        var.oidc_provider.client_ids != null &&
+        var.oidc_provider.thumbprint_url != null
+      )
+    )
+    error_message = "When `var.create_oidc_provider` is true, `client_ids` and `thumbprint_url` must be provided."
   }
 }
 


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
-  `var.oidc_provider.client_ids`  & `var.oidc_provider.thumbprint_url` are only needed when `var.create_oidc_provider` is set to true.
- If `var.create_oidc_provider` is set to false only the `url` is needed to be able to datasource the already existing provider.

To prevent passing down information that is not used when setting `var.create_oidc_provider` to false, `var.oidc_provider.client_ids`  & `var.oidc_provider.thumbprint_url`  are now optional variables with validation in place to ensure they are provided when `var.create_oidc_provider` is set to true.
