### PR TITLE
bug: Correction to audience logic condition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
     }
 
     dynamic "condition" {
-      for_each = length(each.value.audience_filters) == 0 ? [each.value.audience_filters] : []
+      for_each = length(each.value.audience_filters) == 0 ? [] : [each.value.audience_filters]
       content {
         test     = "ForAnyValue:StringLike"
         variable = "${local.provider.url}:aud"


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
Correcting the logic. When there is NO audience, then no audience should be set instead of if there IS an audience.

**:rocket: Motivation**
<!-- Why is this change required? What problem does it solve? -->

**:pencil: Additional Information**
<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to Confluence, Microsoft Docs, or images that may help with reviewing the PR. -->
