### PR TITLE
bug: Correct optional setting for thumbprint_url

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   provider             = var.create_oidc_provider ? aws_iam_openid_connect_provider.default["create"] : data.aws_iam_openid_connect_provider.default["create"]
-  thumbprint_url_parse = provider::corefunc::url_parse(var.oidc_provider.thumbprint_url)
+  thumbprint_url_parse = var.create_oidc_provider ? provider::corefunc::url_parse(var.oidc_provider.thumbprint_url) : ""
 }
 
 ################################################################################
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
     condition {
       test     = "ForAnyValue:StringLike"
       variable = "${local.provider.url}:sub"
-      values   = each.value.subject_filters
+      values   = each.value.subject_filters˜
     }
 
     dynamic "condition" {

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   provider             = var.create_oidc_provider ? aws_iam_openid_connect_provider.default["create"] : data.aws_iam_openid_connect_provider.default["create"]
-  thumbprint_url_parse = var.create_oidc_provider ? provider::corefunc::url_parse(var.oidc_provider.thumbprint_url) : ""
+  thumbprint_url_parse = var.create_oidc_provider ? provider::corefunc::url_parse(var.oidc_provider.thumbprint_url) : null
 }
 
 ################################################################################
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
     condition {
       test     = "ForAnyValue:StringLike"
       variable = "${local.provider.url}:sub"
-      values   = each.value.subject_filters˜
+      values   = each.value.subject_filters
     }
 
     dynamic "condition" {


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
When no thumbprint_url is set, it currently fails as a local object is expecting it. Correcting that with a condition.

**:rocket: Motivation**
<!-- Why is this change required? What problem does it solve? -->

**:pencil: Additional Information**
<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to Confluence, Microsoft Docs, or images that may help with reviewing the PR. -->
